### PR TITLE
Add Codex CI/CD workflow for issue-driven automation

### DIFF
--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -1,0 +1,33 @@
+name: Codex Issue Automation
+
+on:
+  issues:
+    types: [opened, labeled]
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  codex:
+    # Run when an issue is labeled with `codex`, when someone comments `@codex`,
+    # or when started manually.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'issues' && github.event.label.name == 'codex') ||
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@codex'))
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run Codex
+        uses: openai/codex-action@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -4,3 +4,18 @@ Spetro is a Fluent Design client for the NewsBlur (http://newsblur.com) service 
 ![VirtualSurface](images/spectro.jpg)
 
 Currently looking for a new maintainer for this project, please message me on twitter at @clarkezone if you are interested.
+
+## Codex CI/CD for GitHub Issues
+
+This repository includes a dedicated GitHub Actions workflow at `.github/workflows/codex.yml` to let Codex work directly from GitHub issues.
+
+### Setup
+1. Add a repository secret named `OPENAI_API_KEY` with an API key that can run Codex.
+2. In GitHub, add the `codex` label (optional, but recommended).
+
+### Triggers
+The Codex workflow runs when:
+- an issue is labeled `codex`,
+- a new issue comment contains `@codex`, or
+- the workflow is started manually via **workflow_dispatch**.
+


### PR DESCRIPTION
### Motivation
- Enable automated Codex runs driven from GitHub issues and comments so the repository can be acted on via issue requests. 
- Provide a documented, reproducible way to grant Codex the permissions it needs to create branches, PRs, and update issues.

### Description
- Add a new GitHub Actions workflow at `/.github/workflows/codex.yml` that triggers on `issues` (opened, labeled), `issue_comment` (created), and `workflow_dispatch` and guards execution to run only for manual dispatch, issues labeled `codex`, or comments containing `@codex`.
- Configure workflow permissions `contents: write`, `pull-requests: write`, and `issues: write` and run `openai/codex-action@v1` with `github-token` and `openai-api-key` set from `secrets.GITHUB_TOKEN` and `secrets.OPENAI_API_KEY`.
- Update `README.md` with setup instructions instructing maintainers to add an `OPENAI_API_KEY` repository secret and (optionally) a `codex` label, and describing the workflow triggers.

### Testing
- Verified the new files and changes with `git status --short && git diff -- .github/workflows/codex.yml README.md`, which completed successfully and showed only the intended additions. 
- Inspected the committed workflow and README contents with `nl -ba .github/workflows/codex.yml | sed -n '1,220p'` and `nl -ba README.md | sed -n '1,260p'`, which succeeded and confirmed the expected content. 
- Performed a network connectivity check with `curl -I https://example.com` which returned a `403` due to the execution environment network egress/proxy, so external endpoint validation could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a71d944c788323a3051802d1c78a98)