### PR TITLE
Upgrade to .NET 10 UWP with original XAML preserved

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build-and-test:
-    runs-on: windows-2022
+    runs-on: windows-latest
     permissions:
       contents: read
 
@@ -18,7 +18,8 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '9.x'
+          dotnet-version: '10.x'
+          dotnet-quality: 'preview'
 
       - name: Locate MSBuild
         shell: pwsh

--- a/src/NewsBlurSharp.TestsCore/NewsBlurSharp.TestsCore.csproj
+++ b/src/NewsBlurSharp.TestsCore/NewsBlurSharp.TestsCore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/NewsBlurSharp/NewsBlurSharp.csproj
+++ b/src/NewsBlurSharp/NewsBlurSharp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/Spectro.Core/Spectro.Core.csproj
+++ b/src/Spectro.Core/Spectro.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/Spectro.ViewModels.Tests/Spectro.ViewModels.Tests.csproj
+++ b/src/Spectro.ViewModels.Tests/Spectro.ViewModels.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Spectro.ViewModels/Spectro.ViewModels.csproj
+++ b/src/Spectro.ViewModels/Spectro.ViewModels.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>Spectro</RootNamespace>
   </PropertyGroup>
 

--- a/src/Spectro/App.xaml
+++ b/src/Spectro/App.xaml
@@ -1,4 +1,4 @@
-<Application x:Class="Spectro.App"
+﻿<Application x:Class="Spectro.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vms="using:Spectro.ViewModels"
@@ -7,7 +7,6 @@
     <Application.Resources>
         <ResourceDictionary>
             <vms:ViewModelLocator x:Key="Locator" />
-
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="/Styles/TextBlock.xaml" />
                 <ResourceDictionary Source="/Styles/FluentGlobal.xaml" />

--- a/src/Spectro/Controls/LoginControl.xaml
+++ b/src/Spectro/Controls/LoginControl.xaml
@@ -1,7 +1,9 @@
 ﻿<UserControl x:Class="Spectro.Controls.LoginControl"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:behaviors="using:Cimbalino.Toolkit.Behaviors"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              DataContext="{Binding Login, Source={StaticResource Locator}}"
              mc:Ignorable="d">
@@ -44,28 +46,30 @@
                 uPassword
             </TextBlock>
 
-             <PasswordBox x:Name="Password"
-                          Grid.Row="1"
-                          Grid.Column="1"
-                          Width="200"
-                          VerticalAlignment="Center"
-                          PasswordChanged="Password_PasswordChanged"
-                          KeyDown="Password_KeyDown"
-                          />
+            <PasswordBox x:Name="Password"
+                         Grid.Row="1"
+                         Grid.Column="1"
+                         Width="200"
+                         VerticalAlignment="Center"
+                         Password="{Binding Password, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
+                <interactivity:Interaction.Behaviors>
+                    <behaviors:EnterKeyBehavior Command="{x:Bind ViewModel.LoginCommand}" />
+                </interactivity:Interaction.Behaviors>
+            </PasswordBox>
 
             <Button Grid.Row="2"
                     Grid.Column="0"
                     Grid.ColumnSpan="2"
                     Margin="0,12"
                     HorizontalAlignment="Stretch"
-                    Command="{Binding LoginCommand}"
-                    IsEnabled="{Binding CanLogIn, Mode=OneWay}">
+                    Command="{x:Bind ViewModel.LoginCommand}"
+                    IsEnabled="{x:Bind ViewModel.CanLogIn, Mode=OneWay}">
                 <Grid HorizontalAlignment="Center"
                       VerticalAlignment="Center">
                     <TextBlock Text="Login"
-                               Visibility="{Binding IsLoggingIn, Mode=OneWay, Converter={StaticResource InverseBooleanToVisibilityConverter}}" />
-                     <ProgressRing IsActive="{Binding IsLoggingIn, Mode=OneWay}"
-                                   Visibility="{Binding IsLoggingIn, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                               Visibility="{x:Bind ViewModel.IsLoggingIn, Mode=OneWay, Converter={StaticResource InverseBooleanToVisibilityConverter}}" />
+                    <ProgressRing IsActive="{x:Bind ViewModel.IsLoggingIn, Mode=OneWay}"
+                                  Visibility="{x:Bind ViewModel.IsLoggingIn, Mode=OneWay}" />
                 </Grid>
             </Button>
         </Grid>

--- a/src/Spectro/Controls/LoginControl.xaml.cs
+++ b/src/Spectro/Controls/LoginControl.xaml.cs
@@ -1,8 +1,4 @@
-using Spectro.ViewModels;
-using Windows.System;
-using Windows.UI.Xaml;
-using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Input;
+﻿using Spectro.ViewModels;
 
 namespace Spectro.Controls
 {
@@ -16,22 +12,6 @@ namespace Spectro.Controls
         public LoginControl()
         {
             InitializeComponent();
-        }
-
-        private void Password_KeyDown(object sender, KeyRoutedEventArgs e)
-        {
-            if (e.Key == VirtualKey.Enter && ViewModel?.LoginCommand?.CanExecute(null) == true)
-            {
-                ViewModel.LoginCommand.Execute(null);
-            }
-        }
-
-        private void Password_PasswordChanged(object sender, RoutedEventArgs e)
-        {
-            if (sender is PasswordBox passwordBox && ViewModel != null)
-            {
-                ViewModel.Password = passwordBox.Password;
-            }
         }
     }
 }

--- a/src/Spectro/Properties/PublishProfiles/win-arm64.pubxml
+++ b/src/Spectro/Properties/PublishProfiles/win-arm64.pubxml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <Platform>ARM64</Platform>
+    <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
+    <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
+    <SelfContained>true</SelfContained>
+  </PropertyGroup>
+</Project>

--- a/src/Spectro/Properties/PublishProfiles/win-x64.pubxml
+++ b/src/Spectro/Properties/PublishProfiles/win-x64.pubxml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <Platform>x64</Platform>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
+    <SelfContained>true</SelfContained>
+  </PropertyGroup>
+</Project>

--- a/src/Spectro/Properties/PublishProfiles/win-x86.pubxml
+++ b/src/Spectro/Properties/PublishProfiles/win-x86.pubxml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <Platform>x86</Platform>
+    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
+    <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
+    <SelfContained>true</SelfContained>
+  </PropertyGroup>
+</Project>

--- a/src/Spectro/Properties/launchSettings.json
+++ b/src/Spectro/Properties/launchSettings.json
@@ -1,0 +1,7 @@
+{
+  "profiles": {
+    "Spectro": {
+      "commandName": "MsixPackage"
+    }
+  }
+}

--- a/src/Spectro/Shims/Cimbalino/Toolkit/Converters/BooleanToVisibilityConverter.cs
+++ b/src/Spectro/Shims/Cimbalino/Toolkit/Converters/BooleanToVisibilityConverter.cs
@@ -2,7 +2,7 @@ using System;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Data;
 
-namespace Spectro.Shims.Converters
+namespace Cimbalino.Toolkit.Converters
 {
     public class BooleanToVisibilityConverter : IValueConverter
     {

--- a/src/Spectro/Shims/Cimbalino/Toolkit/Converters/NegativeBooleanConverter.cs
+++ b/src/Spectro/Shims/Cimbalino/Toolkit/Converters/NegativeBooleanConverter.cs
@@ -1,7 +1,7 @@
 using System;
 using Windows.UI.Xaml.Data;
 
-namespace Spectro.Shims.Converters
+namespace Cimbalino.Toolkit.Converters
 {
     public class NegativeBooleanConverter : IValueConverter
     {

--- a/src/Spectro/Shims/Cimbalino/Toolkit/Services/ApplicationSettingsService.cs
+++ b/src/Spectro/Shims/Cimbalino/Toolkit/Services/ApplicationSettingsService.cs
@@ -21,7 +21,7 @@ namespace Cimbalino.Toolkit.Services
 
             public bool Contains(string key) => _container.Values.ContainsKey(key);
 
-            public T Get<T>(string key) => Get(key, default);
+            public T Get<T>(string key) => Get<T>(key, default(T));
 
             public T Get<T>(string key, T defaultValue)
                 => _container.Values.TryGetValue(key, out var value) && value is T castValue ? castValue : defaultValue;

--- a/src/Spectro/Shims/Microsoft/Toolkit/Uwp/UI/Controls/ImageEx.cs
+++ b/src/Spectro/Shims/Microsoft/Toolkit/Uwp/UI/Controls/ImageEx.cs
@@ -4,8 +4,17 @@ using Windows.UI.Xaml.Media;
 
 namespace Microsoft.Toolkit.Uwp.UI.Controls
 {
-    public class ImageEx : Image
+    public class ImageEx : Control
     {
+        public ImageSource Source
+        {
+            get => (ImageSource)GetValue(SourceProperty);
+            set => SetValue(SourceProperty, value);
+        }
+
+        public static readonly DependencyProperty SourceProperty =
+            DependencyProperty.Register(nameof(Source), typeof(ImageSource), typeof(ImageEx), new PropertyMetadata(null));
+
         public bool IsCacheEnabled
         {
             get => (bool)GetValue(IsCacheEnabledProperty);

--- a/src/Spectro/Spectro.csproj
+++ b/src/Spectro/Spectro.csproj
@@ -1,21 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>AppContainerExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.26100.0</TargetFramework>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net10.0-windows10.0.26100.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.19041.0</TargetPlatformMinVersion>
     <RootNamespace>Spectro</RootNamespace>
     <AssemblyName>Spectro</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
-    <ApplicationManifest>Package.appxmanifest</ApplicationManifest>
-    <Platforms>x86;x64;ARM64</Platforms>
     <UseUwp>true</UseUwp>
-    <UseUwpTools>true</UseUwpTools>
-    <WindowsSdkPackageVersion>10.0.26100.1</WindowsSdkPackageVersion>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <Platforms>x86;x64;ARM64</Platforms>
+    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <PublishAot>true</PublishAot>
+    <PublishProfile>win-$(Platform).pubxml</PublishProfile>
+    <DisableRuntimeMarshalling>true</DisableRuntimeMarshalling>
+    <EnableMsixTooling>true</EnableMsixTooling>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
   <ItemGroup>
@@ -29,9 +27,5 @@
     <ProjectReference Include="..\NewsBlurSharp\NewsBlurSharp.csproj" />
     <ProjectReference Include="..\Spectro.Core\Spectro.Core.csproj" />
     <ProjectReference Include="..\Spectro.ViewModels\Spectro.ViewModels.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PRIResource Include="Strings\en-us\Resources.resw" />
   </ItemGroup>
 </Project>

--- a/src/Spectro/Styles/Converters.xaml
+++ b/src/Spectro/Styles/Converters.xaml
@@ -1,9 +1,8 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:converters="using:Spectro.Shims.Converters">
+                    xmlns:converters="using:Cimbalino.Toolkit.Converters">
 
     <converters:NegativeBooleanConverter x:Key="NegativeBooleanConverter" />
-    <converters:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
     <converters:BooleanToVisibilityConverter x:Key="InverseBooleanToVisibilityConverter"
                                              InvertValue="True" />
 </ResourceDictionary>

--- a/src/Spectro/Views/NavigationRoot.xaml
+++ b/src/Spectro/Views/NavigationRoot.xaml
@@ -1,8 +1,10 @@
 ﻿<local:SpectroViewBase x:Class="Spectro.Views.NavigationRoot"
                        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                       xmlns:behaviors="using:Microsoft.Toolkit.Uwp.UI.Animations.Behaviors"
                        xmlns:controls="using:Spectro.Controls"
                        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                       xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
                        xmlns:local="using:Spectro.Views"
                        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                        DataContext="{Binding NavViewModel, Source={StaticResource Locator}}"
@@ -10,6 +12,12 @@
 
     <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
         <Grid x:Name="GridToBeBlurred">
+            <interactivity:Interaction.Behaviors>
+                <behaviors:Blur x:Name="BlurBehaviour"
+                                AutomaticallyStart="True"
+                                Value="{x:Bind BlurAmount(ViewModel.IsLoggedIn), Mode=OneWay}"
+                                Duration="0.5" />
+            </interactivity:Interaction.Behaviors>
             <NavigationView x:Name="NavView"
                             AlwaysShowHeader="False"
                             IsSettingsVisible="True"
@@ -81,32 +89,32 @@
                                        Height="25"
                                        Margin="12,0,12,0">
                             <PersonPicture.ProfilePicture>
-                                <BitmapImage UriSource="{Binding ProfileImageUri, Mode=OneWay}" />
+                                <BitmapImage UriSource="{x:Bind ViewModel.ProfileImageUri, Mode=OneWay}" />
                             </PersonPicture.ProfilePicture>
                         </PersonPicture>
                         <HyperlinkButton x:Name="MoreInfoBtn"
-                                         Command="{Binding LoginLogoutCommand}"
-                                         Content="{Binding LoginButtonText, Mode=OneWay}" />
+                                         Command="{x:Bind ViewModel.LoginLogoutCommand}"
+                                         Content="{x:Bind ViewModel.LoginButtonText, Mode=OneWay}" />
                     </StackPanel>
                 </NavigationView.PaneFooter>
                 <Frame x:Name="AppNavFrame" />
             </NavigationView>
         </Grid>
 
-        <controls:LoginControl Visibility="{Binding IsLoggedIn, Mode=OneWay, Converter={StaticResource InverseBooleanToVisibilityConverter}}" />
+        <controls:LoginControl Visibility="{x:Bind ViewModel.IsLoggedIn, Mode=OneWay, Converter={StaticResource InverseBooleanToVisibilityConverter}}" />
 
         <!--  how to handle position with / without back button  -->
         <TextBlock Margin="12,8,0,0"
                    VerticalAlignment="Top"
                    Style="{ThemeResource CaptionTextBlockStyle}"
-                   Text="{Binding ApplicationName}" />
+                   Text="{x:Bind ViewModel.ApplicationName}" />
 
-         <ProgressBar x:Name="ServiceProgress"
-                      Height="10"
-                      HorizontalAlignment="Stretch"
-                      VerticalAlignment="Top"
-                      IsEnabled="{Binding IsProgressVisible, Mode=OneWay}"
-                      IsIndeterminate="{Binding IsProgressVisible, Mode=OneWay}"
-                      Visibility="{Binding IsProgressVisible, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
-     </Grid>
- </local:SpectroViewBase>
+        <ProgressBar x:Name="ServiceProgress"
+                     Height="10"
+                     HorizontalAlignment="Stretch"
+                     VerticalAlignment="Top"
+                     IsEnabled="{x:Bind ViewModel.IsProgressVisible, Mode=OneWay}"
+                     IsIndeterminate="{x:Bind ViewModel.IsProgressVisible, Mode=OneWay}"
+                     Visibility="{x:Bind BooleanToVisibility(ViewModel.IsProgressVisible), Mode=OneWay}" />
+    </Grid>
+</local:SpectroViewBase>

--- a/src/Spectro/Views/NavigationRoot.xaml.cs
+++ b/src/Spectro/Views/NavigationRoot.xaml.cs
@@ -1,4 +1,4 @@
-using Spectro.Core.Interfaces;
+﻿using Spectro.Core.Interfaces;
 using Spectro.ViewModels;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Navigation;

--- a/src/Spectro/Views/NewsFeedList.xaml
+++ b/src/Spectro/Views/NewsFeedList.xaml
@@ -1,7 +1,10 @@
 ﻿<local:SpectroViewBase x:Class="Spectro.Views.NewsFeedList"
                        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                       xmlns:controls="using:Microsoft.Toolkit.Uwp.UI.Controls"
                        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                       xmlns:dataModel="using:Spectro.Core.DataModel"
+                       xmlns:datamodel="using:Spectro.DataModel"
                        xmlns:local="using:Spectro.Views"
                        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                        DataContext="{Binding NewsList, Source={StaticResource Locator}}"
@@ -28,14 +31,14 @@
             <ListView Margin="0,40,0,50"
                       IsItemClickEnabled="True"
                       ItemClick="ListView_ItemClick"
-                      ItemsSource="{Binding FeedItemSource}">
+                      ItemsSource="{x:Bind Vm.FeedItemSource}">
                 <ListView.ItemContainerStyle>
                     <Style TargetType="ListViewItem">
                         <Setter Property="HorizontalContentAlignment" Value="Stretch" />
                     </Style>
                 </ListView.ItemContainerStyle>
                 <ListView.ItemTemplate>
-                    <DataTemplate>
+                    <DataTemplate x:DataType="datamodel:NewsFeed">
                         <Grid>
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="32" />
@@ -43,16 +46,18 @@
                                 <ColumnDefinition Width="50" />
                             </Grid.ColumnDefinitions>
 
-                            <Image Name="ImageControl"
-                                   Width="20"
-                                   Height="20"
-                                   HorizontalAlignment="Left"
-                                   Source="{Binding IconUri}" />
+                            <controls:ImageEx Name="ImageExControl"
+                                              Width="20"
+                                              Height="20"
+                                              HorizontalAlignment="Left"
+                                              IsCacheEnabled="True"
+                                              PlaceholderSource="ms-appx:///Assets/StoreLogo.png"
+                                              Source="{x:Bind IconUri}" />
                             <TextBlock Grid.Column="1"
-                                       Text="{Binding Title}" />
+                                       Text="{x:Bind Title}" />
                             <TextBlock Grid.Column="2"
                                        HorizontalAlignment="Right"
-                                       Text="{Binding UnreadCount}" />
+                                       Text="{x:Bind UnreadCount}" />
                         </Grid>
                     </DataTemplate>
                 </ListView.ItemTemplate>
@@ -61,6 +66,7 @@
             <StackPanel VerticalAlignment="Bottom"
                         Orientation="Horizontal">
 
+                <!-- <ListView Margin="0,8,0,0" x:Name="lstFilter" ItemsSource="{x:Bind Vm.ItemSource}"> -->
                 <ListView x:Name="lstFilter"
                           Margin="0,8,0,0">
                     <ListView.ItemsPanel>
@@ -113,14 +119,14 @@
 
             <ListView x:Name="stories"
                       Margin="0,40,0,0"
-                      ItemsSource="{Binding StoryItemSource, Mode=OneWay}">
+                      ItemsSource="{x:Bind Vm.StoryItemSource, Mode=OneWay}">
                 <ListView.ItemContainerStyle>
                     <Style TargetType="ListViewItem">
                         <Setter Property="HorizontalContentAlignment" Value="Stretch" />
                     </Style>
                 </ListView.ItemContainerStyle>
                 <ListView.ItemTemplate>
-                    <DataTemplate>
+                    <DataTemplate x:DataType="dataModel:Story">
                         <Grid Height="100">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="*" />
@@ -135,25 +141,25 @@
                             <TextBlock Grid.Row="0"
                                        Grid.Column="0"
                                        FontWeight="Bold"
-                                       Text="{Binding Title}"
+                                       Text="{x:Bind Title}"
                                        TextWrapping="WrapWholeWords" />
                             <TextBlock Grid.Row="1"
                                        Style="{StaticResource NewsListSmallText}"
-                                       Text="{Binding Summary}"
+                                       Text="{x:Bind Summary}"
                                        TextWrapping="WrapWholeWords" />
                             <TextBlock Grid.Row="2"
                                        HorizontalAlignment="Left"
                                        Style="{StaticResource NewsListSmallLightText}"
-                                       Text="{Binding Author}" />
+                                       Text="{x:Bind Author}" />
                             <TextBlock Grid.Row="2"
                                        HorizontalAlignment="Right"
                                        Style="{StaticResource NewsListSmallLightText}"
-                                       Text="{Binding TimeStamp}" />
-                            <Image Grid.RowSpan="3"
-                                   Grid.Column="1"
-                                   Width="140"
-                                   Height="100"
-                                   Source="{Binding ListImage}" />
+                                       Text="{x:Bind TimeStamp}" />
+                            <controls:ImageEx Grid.RowSpan="3"
+                                              Grid.Column="1"
+                                              Width="140"
+                                              Height="100"
+                                              Source="{x:Bind ListImage}" />
                         </Grid>
                     </DataTemplate>
                 </ListView.ItemTemplate>

--- a/src/Spectro/Views/SettingsPage.xaml
+++ b/src/Spectro/Views/SettingsPage.xaml
@@ -2,14 +2,15 @@
                        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                       xmlns:helper="using:Spectro.Helpers"
                        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                        xmlns:services="using:Spectro.Core.Services"
                        xmlns:views="using:Spectro.Views"
                        DataContext="{Binding SettingsViewModel, Source={StaticResource Locator}}"
-                       Loaded="Page_Loaded"
-                       Unloaded="Page_Unloaded"
                        mc:Ignorable="d">
     <Page.Resources>
+        <helper:EnumToBooleanConverter x:Key="EnumToBooleanConverter"
+                                       EnumType="services:SpectroTheme" />
         <Thickness x:Key="SettingsSubheaderMargin">0, 20, 0, 48</Thickness>
         <Thickness x:Key="EightTopMargin">0, 8, 0, 0</Thickness>
     </Page.Resources>
@@ -35,26 +36,26 @@
                                Style="{StaticResource BodyTextStyle}" />
 
                     <StackPanel Margin="{StaticResource EightTopMargin}">
-                        <RadioButton x:Name="LightThemeRadioButton"
-                                     x:Uid="Settings_Theme_Light"
-                                     Command="{Binding SwitchThemeCommand}"
-                                     GroupName="AppTheme">
+                        <RadioButton x:Uid="Settings_Theme_Light"
+                                     Command="{x:Bind ViewModel.SwitchThemeCommand}"
+                                     GroupName="AppTheme"
+                                     IsChecked="{x:Bind ViewModel.ElementTheme, Converter={StaticResource EnumToBooleanConverter}, ConverterParameter=Light, Mode=TwoWay}">
                             <RadioButton.CommandParameter>
                                 <services:SpectroTheme>Light</services:SpectroTheme>
                             </RadioButton.CommandParameter>
                         </RadioButton>
-                        <RadioButton x:Name="DarkThemeRadioButton"
-                                     x:Uid="Settings_Theme_Dark"
-                                     Command="{Binding SwitchThemeCommand}"
-                                     GroupName="AppTheme">
+                        <RadioButton x:Uid="Settings_Theme_Dark"
+                                     Command="{x:Bind ViewModel.SwitchThemeCommand}"
+                                     GroupName="AppTheme"
+                                     IsChecked="{x:Bind ViewModel.ElementTheme, Converter={StaticResource EnumToBooleanConverter}, ConverterParameter=Dark, Mode=TwoWay}">
                             <RadioButton.CommandParameter>
                                 <services:SpectroTheme>Dark</services:SpectroTheme>
                             </RadioButton.CommandParameter>
                         </RadioButton>
-                        <RadioButton x:Name="DefaultThemeRadioButton"
-                                     x:Uid="Settings_Theme_Default"
-                                     Command="{Binding SwitchThemeCommand}"
-                                     GroupName="AppTheme">
+                        <RadioButton x:Uid="Settings_Theme_Default"
+                                     Command="{x:Bind ViewModel.SwitchThemeCommand}"
+                                     GroupName="AppTheme"
+                                     IsChecked="{x:Bind ViewModel.ElementTheme, Converter={StaticResource EnumToBooleanConverter}, ConverterParameter=Default, Mode=TwoWay}">
                             <RadioButton.CommandParameter>
                                 <services:SpectroTheme>Default</services:SpectroTheme>
                             </RadioButton.CommandParameter>
@@ -66,7 +67,7 @@
                            Style="{StaticResource SubtitleTextBlockStyle}" />
 
                 <StackPanel Margin="{StaticResource EightTopMargin}">
-                    <TextBlock Text="{Binding VersionDescription, Mode=OneWay}" />
+                    <TextBlock Text="{x:Bind ViewModel.VersionDescription, Mode=OneWay}" />
                     <TextBlock x:Uid="Settings_AboutDescription"
                                Margin="{StaticResource EightTopMargin}" />
 
@@ -95,3 +96,4 @@
         </VisualStateManager.VisualStateGroups>
     </Grid>
 </views:SpectroViewBase>
+

--- a/src/Spectro/Views/SettingsPage.xaml.cs
+++ b/src/Spectro/Views/SettingsPage.xaml.cs
@@ -1,6 +1,4 @@
-using System.ComponentModel;
-using Spectro.ViewModels;
-using Spectro.Core.Services;
+﻿using Spectro.ViewModels;
 namespace Spectro.Views
 {
     public sealed partial class SettingsPage
@@ -12,43 +10,6 @@ namespace Spectro.Views
         public SettingsPage()
         {
             InitializeComponent();
-        }
-
-        private void Page_Loaded(object sender, Windows.UI.Xaml.RoutedEventArgs e)
-        {
-            if (ViewModel == null)
-            {
-                return;
-            }
-
-            ViewModel.PropertyChanged -= ViewModel_PropertyChanged;
-            ViewModel.PropertyChanged += ViewModel_PropertyChanged;
-            UpdateThemeSelection();
-        }
-
-        private void Page_Unloaded(object sender, Windows.UI.Xaml.RoutedEventArgs e)
-        {
-            if (ViewModel == null)
-            {
-                return;
-            }
-
-            ViewModel.PropertyChanged -= ViewModel_PropertyChanged;
-        }
-
-        private void ViewModel_PropertyChanged(object sender, PropertyChangedEventArgs e)
-        {
-            if (e.PropertyName == nameof(SettingsViewModel.ElementTheme))
-            {
-                UpdateThemeSelection();
-            }
-        }
-
-        private void UpdateThemeSelection()
-        {
-            LightThemeRadioButton.IsChecked = ViewModel.ElementTheme == SpectroTheme.Light;
-            DarkThemeRadioButton.IsChecked = ViewModel.ElementTheme == SpectroTheme.Dark;
-            DefaultThemeRadioButton.IsChecked = ViewModel.ElementTheme == SpectroTheme.Default;
         }
     }
 }


### PR DESCRIPTION
Upgrade all projects from .NET 9 to .NET 10 following the modern UWP project template pattern, fixing the WMC9999 XAML compiler crash and restoring all original XAML.

## Root Cause
The .NET 9 UWP tooling (`UseUwpTools` + `WindowsSdkPackageVersion`) used an older XAML compiler that crashed (WMC9999 NullReferenceException) on custom types during MarkupCompilePass1. The .NET 10 built-in XAML compiler handles them correctly, making all the previous .NET 9 XAML workarounds unnecessary.

## Changes

### .NET 10 Upgrade
- All 6 projects upgraded to `net10.0` target framework
- `Spectro.csproj`: Follows modern UWP template — `OutputType=WinExe`, `UseUwp=true` (removed `UseUwpTools`/`WindowsSdkPackageVersion`), added `RuntimeIdentifiers`, `DisableRuntimeMarshalling`, `EnableMsixTooling`, `PublishProfile`

### XAML Restored
- Reverted all .NET 9 XAML workarounds — original x:Bind, DataContext bindings, converters, SpectroTheme enums all restored
- The .NET 10 XAML compiler handles all of these correctly

### Infrastructure
- Added `launchSettings.json` (MsixPackage command) for proper VS deployment
- Added publish profiles for x64/x86/arm64
- Fixed `ImageEx` shim (`Image` is sealed in .NET 10)
- Aligned converter shim namespaces to `Cimbalino.Toolkit.Converters`
- Fixed `ApplicationSettingsService` type inference
- CI updated to `windows-latest` with .NET 10 preview SDK